### PR TITLE
initial death marker code

### DIFF
--- a/map/Marker.java
+++ b/map/Marker.java
@@ -65,4 +65,16 @@ public class Marker {
 		Render.setColour(this.colour);
 		Render.drawRect(p.x - halfMSize + 0.5, p.y - halfMSize + 0.5, mSize - 1.0, mSize - 1.0);
 	}
+
+	// arraylist.contains wasn't producing expected results in some situations
+	// rather than figure out why i'll just control how two markers are compared
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) { return true; }
+		if (o instanceof Marker) {
+			Marker m = (Marker) o;
+			return (name == m.name) && (groupName == m.groupName) && (x == m.x) && (y == m.y) && (z == m.z) && (dimension == m.dimension);
+		}
+		return false;
+	}
 }

--- a/map/MarkerManager.java
+++ b/map/MarkerManager.java
@@ -2,6 +2,8 @@ package mapwriter.map;
 
 import java.util.ArrayList;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import mapwriter.MwUtil;
 import mapwriter.forge.MwConfig;
 import mapwriter.map.mapmode.MapMode;
@@ -203,6 +205,23 @@ public class MarkerManager {
 			}
 		}
 		return count;
+	}
+
+	// filtering via guava's Iterables.filter so make note these
+	// markers are returned as a view of the original collection they are not cloned
+	// changes to these effect the markers in markerList
+	public Marker[] getMarkersInGroup(final String group) {
+		if (group.equals("all")) {
+			return this.markerList.toArray(new Marker[0]);
+		} else {
+			Iterable<Marker> matchingGroups = Iterables.filter(markerList, new Predicate<Marker>() {
+                @Override
+                public boolean apply(final Marker input) {
+                    return input.groupName.equals(group);
+                }
+            });
+			return Iterables.toArray(matchingGroups, Marker.class);
+		}
 	}
 	
 	public void selectNextMarker() {


### PR DESCRIPTION
working death marker implementation... the only thing I'd look to change in the future is to make the number of total death markers a configurable amount rather than hard coding a limit of 3. 

In a different local branch I've changed Marker a bit to allow an icon rather than a color (currently all the entity heads are the only options) the equals() method on Marker and the getMarkersInGroup method in MarkerManager are cherry picked from there since they made things easier-- I don't know if you have an opinion one way or another when it comes to using Guava; you don't make use of it anywhere so my getMarkersInGroup method introduces a dependency in MarkerManager but since MW is a Forge mod Guava will be available and it's not an issue... If you have plans to un-join MW and Forge for some reason I figured I'd mention it.
