### PR TITLE
Render map when chat or ingame menu is open

### DIFF
--- a/src/main/java/mapwriter/Mw.java
+++ b/src/main/java/mapwriter/Mw.java
@@ -599,7 +599,7 @@ public class Mw {
 					this.onPlayerDeath();
 					this.onPlayerDeathAlreadyFired = true;
 				}
-			} else if (this.mc.currentScreen == null) {
+			} else if (!(this.mc.currentScreen instanceof MwGui)) {
 				// if the player is not dead
 				this.onPlayerDeathAlreadyFired = false;
 				// if in game (no gui screen) center the minimap on the player and render it.


### PR DESCRIPTION
I find it ugly when the map disappears when you open chat, your inventory, the ingame menu and any other kind of ingame gui. In my previous PR i did an attempt on fixing this, accidentally creating the flickering map bug. This PR lets the maps render in guis, but not in the map gui so doesn't cause the flickering. I have tested this and it works properly.
