### PR TITLE
Use the /seed command to determine the world seed

### DIFF
--- a/src/main/java/mapwriter/Mw.java
+++ b/src/main/java/mapwriter/Mw.java
@@ -1,21 +1,12 @@
 package mapwriter;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-
 import mapwriter.forge.MwConfig;
 import mapwriter.forge.MwForge;
 import mapwriter.forge.MwKeyHandler;
 import mapwriter.gui.MwGui;
 import mapwriter.gui.MwGuiMarkerDialog;
-import mapwriter.map.MapTexture;
-import mapwriter.map.MapView;
-import mapwriter.map.Marker;
-import mapwriter.map.MarkerManager;
-import mapwriter.map.MiniMap;
-import mapwriter.map.Trail;
-import mapwriter.map.UndergroundTexture;
+import mapwriter.map.*;
+import mapwriter.overlay.OverlaySlime;
 import mapwriter.region.BlockColours;
 import mapwriter.region.RegionManager;
 import mapwriter.tasks.CloseRegionManagerTask;
@@ -26,6 +17,10 @@ import net.minecraft.server.integrated.IntegratedServer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /*
 
@@ -555,7 +550,9 @@ public class Mw {
 			this.saveConfig();
 			
 			this.tickCounter = 0;
-		}
+
+            OverlaySlime.reset(); //Reset the state so the seed will be asked again when we log in
+        }
 	}
 	
 	////////////////////////////////

--- a/src/main/java/mapwriter/forge/EventHandler.java
+++ b/src/main/java/mapwriter/forge/EventHandler.java
@@ -1,9 +1,13 @@
 package mapwriter.forge;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import mapwriter.Mw;
+import mapwriter.overlay.OverlaySlime;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.ChatComponentTranslation;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.event.world.ChunkEvent;
 import net.minecraftforge.event.world.WorldEvent;
-import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class EventHandler {
 	
@@ -33,11 +37,34 @@ public class EventHandler {
 			this.mw.onWorldLoad(event.world);
 		}
 	}
-	
-	@SubscribeEvent
-	public void eventWorldUnload(WorldEvent.Unload event){
+
+    @SubscribeEvent
+    public void eventWorldUnload(WorldEvent.Unload event){
         if(event.world.isRemote){
             this.mw.onWorldUnload(event.world);
         }
-	}
+    }
+
+    @SubscribeEvent
+    public void onClientChat(ClientChatReceivedEvent event){
+        if(OverlaySlime.seedFound || !OverlaySlime.seedAsked) return;
+        try{ //I don't want to crash the game when we derp up in here
+            if(event.message instanceof ChatComponentTranslation){
+                ChatComponentTranslation component = (ChatComponentTranslation) event.message;
+                if(component.getKey().equals("commands.seed.success")){
+                    OverlaySlime.setSeed((Long) component.getFormatArgs()[0]);
+                    event.setCanceled(true); //Don't let the player see this seed message, They didn't do /seed, we did
+                }
+            }else if(event.message instanceof ChatComponentText){
+                ChatComponentText component = (ChatComponentText) event.message;
+                String msg = component.getUnformattedText();
+                if(msg.startsWith("Seed: ")){ //Because bukkit...
+                    OverlaySlime.setSeed(Long.parseLong(msg.substring(6)));
+                    event.setCanceled(true); //Don't let the player see this seed message, They didn't do /seed, we did
+                }
+            }
+        }catch(Exception e){
+            //e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/mapwriter/forge/MwForge.java
+++ b/src/main/java/mapwriter/forge/MwForge.java
@@ -1,18 +1,5 @@
 package mapwriter.forge;
 
-import java.net.InetSocketAddress;
-
-import mapwriter.Mw;
-import mapwriter.api.MwAPI;
-import mapwriter.overlay.OverlayGrid;
-import mapwriter.overlay.OverlaySlime;
-import net.minecraft.client.Minecraft;
-import net.minecraftforge.client.event.RenderGameOverlayEvent;
-import net.minecraftforge.common.MinecraftForge;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
@@ -24,6 +11,17 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.network.FMLNetworkEvent;
+import mapwriter.Mw;
+import mapwriter.api.MwAPI;
+import mapwriter.overlay.OverlayGrid;
+import mapwriter.overlay.OverlaySlime;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.common.MinecraftForge;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.InetSocketAddress;
 
 @Mod(modid="MapWriter", name="MapWriter", version="2.1.0")
 public class MwForge {


### PR DESCRIPTION
world.getSeed() only works server-side, returning -1 on the client and so making the slime overlay useless. This PR makes the OverlaySlime use the /seed command to determine the seed and then rendering the overlay. When no proper response is found, the overlay stays empty.
